### PR TITLE
fix(reports): make visual search resilient to a failing provider

### DIFF
--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -8,7 +8,6 @@ import { CACHE_MANAGER } from "@nestjs/cache-manager";
 import type { Cache } from "cache-manager";
 import { VisionService } from "../vision/vision.service";
 import {
-  VisualSearchResult,
   ArtworksReport,
   Artwork,
   ArtworksReportGet,
@@ -50,19 +49,24 @@ export class ReportsService {
     imageBuffer: Buffer,
     imageDownloadUrl: string
   ): Promise<MatchingPageGet[]> {
-    const visualSearchResults = await Promise.all([
+    const settledResults = await Promise.allSettled([
       this.visionService.searchImage(imageBuffer),
       this.googleLensService.searchImage(imageDownloadUrl)
     ]);
-    const matchingPages = visualSearchResults.reduce<MatchingPageGet[]>(
-      (acc: MatchingPageGet[], value: VisualSearchResult | null) => {
-        if (value) {
-          acc.push(...value.matchingPages);
-        }
-        return acc;
-      },
-      []
-    );
+    const providers = ["vision", "googleLens"] as const;
+    const matchingPages: MatchingPageGet[] = [];
+    settledResults.forEach((result, index) => {
+      if (result.status === "rejected") {
+        this.logger.error(
+          `Visual search provider "${providers[index]}" failed`,
+          result.reason
+        );
+        return;
+      }
+      if (result.value) {
+        matchingPages.push(...result.value.matchingPages);
+      }
+    });
     return matchingPages;
   }
 


### PR DESCRIPTION
## Problem

Scans 500'd on deployed dev (`POST /reports/user/:id`) while working locally. Root cause of the *crash*: `aggregateVisualSearchResults` ran Vision + Google Lens under `Promise.all`, so if **either** provider rejected (e.g. a bad BrightData key/zone or missing Google Vision ADC credentials in the deployed container), the entire scan request threw a 500.

## Change

- `Promise.all` → **`Promise.allSettled`**: a single failing provider no longer takes down the whole scan; the report is still built from the healthy provider's matches.
- Rejections are logged with the provider name (`Visual search provider "vision" failed` / `"googleLens" failed`) plus the underlying error, so the deployed log reveals **which** credential is broken.
- Removed the now-unused `VisualSearchResult` import.

## Scope / caveats

- This is **resilience hardening, not the root-cause fix.** If a provider's credentials are misconfigured on dev, scans will now succeed at *half coverage* (only the working provider). The broken credential (BrightData `GOOGLE_LENS_API_KEY`/`BRIGHTDATA_SERP_API_ZONE`, or Google Vision service-account/ADC) still needs correcting — the new log line identifies which.
- If **both** providers fail, the scan now creates an empty (0-match) report instead of 500ing.

## Testing

- `pnpm build` (nest build) compiles successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)