### PR TITLE
feat(reports): async scan endpoint with live progress

### DIFF
--- a/backend/src/googlelens/googlelens.service.ts
+++ b/backend/src/googlelens/googlelens.service.ts
@@ -39,7 +39,7 @@ export class GoogleLensService {
           url: `https://lens.google.com/uploadbyurl?url=${url}&brd_lens=exact_matches`,
           format: "raw"
         },
-        { headers }
+        { headers, timeout: 30000 }
       )
     );
     if (!data || !data.exact_matches) {

--- a/backend/src/reports/reports.controller.ts
+++ b/backend/src/reports/reports.controller.ts
@@ -19,7 +19,11 @@ import {
   ArtworksReportGlobalStatistics,
   ArtworksReportStatistics,
   ArtworksReportStatisticsDTO,
-  ArtworksReportGlobalStatisticsDTO
+  ArtworksReportGlobalStatisticsDTO,
+  ScanEnqueuedDTO,
+  ScanStatusDTO,
+  ScanEnqueued,
+  ScanStatus
 } from "@vigilart/shared";
 import { ApiEndpoint } from "../common/decorators/api-endpoint.decorator";
 import { ApiParam, ApiQuery } from "@nestjs/swagger";
@@ -45,6 +49,44 @@ export class ReportsController {
     @Param("id", ParseUUIDPipe) userId: string
   ): Promise<ArtworksReport> {
     return this.reportsService.generate(userId);
+  }
+
+  @Post("user/:id/scan")
+  @ApiEndpoint({
+    summary: "Enqueue an async scan for all artworks owned by a user",
+    success: {
+      status: HttpStatus.OK,
+      type: ScanEnqueuedDTO
+    },
+    protected: true,
+    errors: [HttpStatus.NOT_FOUND, HttpStatus.FORBIDDEN],
+    ownerships: [{ data: "id", userField: "id", type: "params" }]
+  })
+  @ApiParam({ name: "id", type: String })
+  async enqueueScan(
+    @Param("id", ParseUUIDPipe) userId: string
+  ): Promise<ScanEnqueued> {
+    return this.reportsService.enqueueScan(userId);
+  }
+
+  @Get("user/:id/scan/:jobId")
+  @ApiEndpoint({
+    summary: "Get the status/progress of an async scan job",
+    success: {
+      status: HttpStatus.OK,
+      type: ScanStatusDTO
+    },
+    protected: true,
+    errors: [HttpStatus.NOT_FOUND],
+    ownerships: [{ data: "id", userField: "id", type: "params" }]
+  })
+  @ApiParam({ name: "id", type: String })
+  @ApiParam({ name: "jobId", type: String })
+  async getScanStatus(
+    @Param("id", ParseUUIDPipe) userId: string,
+    @Param("jobId") jobId: string
+  ): Promise<ScanStatus> {
+    return this.reportsService.getScanStatus(userId, jobId);
   }
 
   @Get("user/:id")

--- a/backend/src/reports/reports.processor.ts
+++ b/backend/src/reports/reports.processor.ts
@@ -13,8 +13,10 @@ export class ReportsProcessor extends WorkerHost {
     super();
   }
 
-  async process(job: Job<GenerateReportJobData>): Promise<void> {
-    if (job.name === GENERATE_REPORT_JOB)
-      await this.reportsService.generate(job.data.userId);
+  async process(job: Job<GenerateReportJobData>): Promise<string | void> {
+    if (job.name === GENERATE_REPORT_JOB) {
+      const report = await this.reportsService.generate(job.data.userId, job);
+      return report.id;
+    }
   }
 }

--- a/backend/src/reports/reports.scheduler.ts
+++ b/backend/src/reports/reports.scheduler.ts
@@ -1,17 +1,14 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { Cron, CronExpression } from "@nestjs/schedule";
-import { InjectQueue } from "@nestjs/bullmq";
-import { Queue } from "bullmq";
 import { PrismaService } from "../prisma/prisma.service";
-import { REPORTS_QUEUE, GENERATE_REPORT_JOB } from "./reports.constants";
-import type { GenerateReportJobData } from "./reports.processor";
+import { ReportsService } from "./reports.service";
 
 @Injectable()
 export class ReportsScheduler {
   private readonly logger = new Logger(ReportsScheduler.name);
 
   constructor(
-    @InjectQueue(REPORTS_QUEUE) private readonly reportsQueue: Queue,
+    private readonly reportsService: ReportsService,
     private readonly prisma: PrismaService
   ) {}
 
@@ -38,16 +35,7 @@ export class ReportsScheduler {
     if (users.length === 0)
       return;
     await Promise.all(
-      users.map((user) => {
-        const jobData: GenerateReportJobData = { userId: user.id };
-
-        return this.reportsQueue.add(GENERATE_REPORT_JOB, jobData, {
-          attempts: 3,
-          backoff: { type: "exponential", delay: 5000 },
-          removeOnComplete: true,
-          removeOnFail: 100
-        });
-      })
+      users.map((user) => this.reportsService.enqueueScheduledScan(user.id))
     );
     this.logger.log(`Successfully enqueued ${users.length} auto-report job(s).`);
   }

--- a/backend/src/reports/reports.service.it-spec.ts
+++ b/backend/src/reports/reports.service.it-spec.ts
@@ -1,6 +1,11 @@
 import { Test, TestingModule } from "@nestjs/testing";
-import { ForbiddenException, ServiceUnavailableException } from "@nestjs/common";
+import {
+  ForbiddenException,
+  NotFoundException,
+  ServiceUnavailableException
+} from "@nestjs/common";
 import { CACHE_MANAGER } from "@nestjs/cache-manager";
+import { getQueueToken } from "@nestjs/bullmq";
 import { ReportsService } from "./reports.service";
 import { VisionService } from "../vision/vision.service";
 import { GoogleLensService } from "../googlelens/googlelens.service";
@@ -8,13 +13,20 @@ import { ArtworksService } from "../artworks/artworks.service";
 import { StorageService } from "../storage/storage.service";
 import { MatchingPagesService } from "./matchingPage.service";
 import { PrismaService } from "../prisma/prisma.service";
-import { MAX_SCANS_PER_WINDOW } from "./reports.constants";
+import { MAX_SCANS_PER_WINDOW, REPORTS_QUEUE } from "./reports.constants";
 
 describe("ReportsService", () => {
   let service: ReportsService;
   let visionService: { searchImage: jest.Mock };
   let googleLensService: { searchImage: jest.Mock };
-  let prisma: { artworksReport: { count: jest.Mock } };
+  let artworksService: { findAllPerUser: jest.Mock };
+  let storageService: { getImage: jest.Mock; getDownloadUrl: jest.Mock };
+  let matchingPagesService: { createMany: jest.Mock };
+  let prisma: {
+    artworksReport: { count: jest.Mock; create: jest.Mock };
+    artwork: { updateMany: jest.Mock };
+  };
+  let queue: { add: jest.Mock; getJob: jest.Mock };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -35,14 +47,22 @@ describe("ReportsService", () => {
             artwork: { updateMany: jest.fn() }
           }
         },
-        { provide: CACHE_MANAGER, useValue: { del: jest.fn() } }
+        { provide: CACHE_MANAGER, useValue: { del: jest.fn() } },
+        {
+          provide: getQueueToken(REPORTS_QUEUE),
+          useValue: { add: jest.fn(), getJob: jest.fn() }
+        }
       ]
     }).compile();
 
     service = module.get(ReportsService);
     visionService = module.get(VisionService);
     googleLensService = module.get(GoogleLensService);
+    artworksService = module.get(ArtworksService);
+    storageService = module.get(StorageService);
+    matchingPagesService = module.get(MatchingPagesService);
     prisma = module.get(PrismaService);
+    queue = module.get(getQueueToken(REPORTS_QUEUE));
   });
 
   afterEach(() => {
@@ -137,6 +157,200 @@ describe("ReportsService", () => {
       const where = prisma.artworksReport.count.mock.calls[0][0].where;
       expect(where.userId).toBe("user-id");
       expect(where.detectionDate.gt).toBeInstanceOf(Date);
+    });
+  });
+
+  describe("generate", () => {
+    const mockScanSuccess = () => {
+      prisma.artworksReport.count.mockResolvedValue(0);
+      artworksService.findAllPerUser.mockResolvedValue([
+        { id: "a1", storageKey: "k1" },
+        { id: "a2", storageKey: "k2" }
+      ]);
+      storageService.getImage.mockResolvedValue(Buffer.from(""));
+      storageService.getDownloadUrl.mockResolvedValue("https://dl.example");
+      visionService.searchImage.mockResolvedValue({ matchingPages: [] });
+      googleLensService.searchImage.mockResolvedValue({ matchingPages: [] });
+      matchingPagesService.createMany.mockResolvedValue({ matchingPages: [] });
+      prisma.artworksReport.create.mockResolvedValue({ id: "report-1" });
+      prisma.artwork.updateMany.mockResolvedValue({ count: 2 });
+    };
+
+    it("Should report progress to the job per artwork", async () => {
+      mockScanSuccess();
+      const job = { updateProgress: jest.fn().mockResolvedValue(undefined) };
+
+      const report = await service.generate("user-id", job as never);
+
+      expect(report).toEqual({ id: "report-1" });
+      expect(job.updateProgress).toHaveBeenCalledWith({
+        processed: 0,
+        total: 2
+      });
+      expect(job.updateProgress).toHaveBeenLastCalledWith({
+        processed: 2,
+        total: 2
+      });
+    });
+
+    it("Should generate without a job (scheduler path)", async () => {
+      mockScanSuccess();
+
+      const report = await service.generate("user-id");
+
+      expect(report).toEqual({ id: "report-1" });
+    });
+
+    it("Should not create a report when over quota", async () => {
+      prisma.artworksReport.count.mockResolvedValue(MAX_SCANS_PER_WINDOW);
+
+      await expect(service.generate("user-id")).rejects.toBeInstanceOf(
+        ForbiddenException
+      );
+      expect(prisma.artworksReport.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("enqueueScan", () => {
+    it("Should enqueue a job with a deterministic per-user id when none exists", async () => {
+      prisma.artworksReport.count.mockResolvedValue(0);
+      queue.getJob.mockResolvedValue(null);
+      queue.add.mockResolvedValue({ id: "scan-user-id" });
+
+      const res = await service.enqueueScan("user-id");
+
+      expect(res).toEqual({ jobId: "scan-user-id" });
+      expect(queue.add).toHaveBeenCalledWith(
+        expect.anything(),
+        { userId: "user-id" },
+        expect.objectContaining({ jobId: "scan-user-id" })
+      );
+    });
+
+    it("Should single-flight an already running scan instead of enqueuing again", async () => {
+      prisma.artworksReport.count.mockResolvedValue(0);
+      queue.getJob.mockResolvedValue({
+        getState: jest.fn().mockResolvedValue("active"),
+        timestamp: Date.now(),
+        processedOn: Date.now()
+      });
+
+      const res = await service.enqueueScan("user-id");
+
+      expect(res).toEqual({ jobId: "scan-user-id" });
+      expect(queue.add).not.toHaveBeenCalled();
+    });
+
+    it("Should replace a terminal job so a fresh scan can run", async () => {
+      prisma.artworksReport.count.mockResolvedValue(0);
+      const remove = jest.fn().mockResolvedValue(undefined);
+      queue.getJob.mockResolvedValue({
+        getState: jest.fn().mockResolvedValue("completed"),
+        timestamp: Date.now(),
+        remove
+      });
+      queue.add.mockResolvedValue({ id: "scan-user-id" });
+
+      const res = await service.enqueueScan("user-id");
+
+      expect(remove).toHaveBeenCalled();
+      expect(queue.add).toHaveBeenCalled();
+      expect(res).toEqual({ jobId: "scan-user-id" });
+    });
+
+    it("Should reject before enqueuing when over quota", async () => {
+      prisma.artworksReport.count.mockResolvedValue(MAX_SCANS_PER_WINDOW);
+
+      await expect(service.enqueueScan("user-id")).rejects.toBeInstanceOf(
+        ForbiddenException
+      );
+      expect(queue.add).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("enqueueScheduledScan", () => {
+    it("Should share the deterministic id and single-flight an in-flight scan", async () => {
+      queue.getJob.mockResolvedValue({
+        getState: jest.fn().mockResolvedValue("active")
+      });
+
+      await service.enqueueScheduledScan("user-id");
+
+      expect(queue.getJob).toHaveBeenCalledWith("scan-user-id");
+      expect(queue.add).not.toHaveBeenCalled();
+    });
+
+    it("Should enqueue with retry options when no job exists", async () => {
+      queue.getJob.mockResolvedValue(null);
+      queue.add.mockResolvedValue({ id: "scan-user-id" });
+
+      await service.enqueueScheduledScan("user-id");
+
+      expect(queue.add).toHaveBeenCalledWith(
+        expect.anything(),
+        { userId: "user-id" },
+        expect.objectContaining({ jobId: "scan-user-id", attempts: 3 })
+      );
+    });
+
+    it("Should not check the interactive quota (enforced later in generate)", async () => {
+      queue.getJob.mockResolvedValue(null);
+      queue.add.mockResolvedValue({ id: "scan-user-id" });
+
+      await service.enqueueScheduledScan("user-id");
+
+      expect(prisma.artworksReport.count).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getScanStatus", () => {
+    it("Should return the reportId when the job is completed", async () => {
+      queue.getJob.mockResolvedValue({
+        data: { userId: "user-id" },
+        getState: jest.fn().mockResolvedValue("completed"),
+        progress: { processed: 2, total: 2 },
+        returnvalue: "report-1",
+        failedReason: undefined
+      });
+
+      const res = await service.getScanStatus("user-id", "scan-user-id");
+
+      expect(res).toMatchObject({
+        jobId: "scan-user-id",
+        state: "completed",
+        progress: { processed: 2, total: 2 },
+        reportId: "report-1"
+      });
+    });
+
+    it("Should throw when the job does not exist", async () => {
+      queue.getJob.mockResolvedValue(null);
+
+      await expect(
+        service.getScanStatus("user-id", "scan-user-id")
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it("Should throw when the job belongs to another user", async () => {
+      queue.getJob.mockResolvedValue({
+        data: { userId: "someone-else" },
+        getState: jest.fn().mockResolvedValue("active")
+      });
+
+      await expect(
+        service.getScanStatus("user-id", "scan-user-id")
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it("Should throw when the job was evicted (unknown state)", async () => {
+      queue.getJob.mockResolvedValue({
+        data: { userId: "user-id" },
+        getState: jest.fn().mockResolvedValue("unknown")
+      });
+
+      await expect(
+        service.getScanStatus("user-id", "scan-user-id")
+      ).rejects.toBeInstanceOf(NotFoundException);
     });
   });
 });

--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -3,10 +3,13 @@ import {
   Inject,
   Injectable,
   Logger,
+  NotFoundException,
   ServiceUnavailableException
 } from "@nestjs/common";
 import { CACHE_MANAGER } from "@nestjs/cache-manager";
 import type { Cache } from "cache-manager";
+import { InjectQueue } from "@nestjs/bullmq";
+import { Job, JobsOptions, Queue } from "bullmq";
 import { VisionService } from "../vision/vision.service";
 import {
   ArtworksReport,
@@ -17,7 +20,11 @@ import {
   MatchingPageGet,
   ApiBatchPayload,
   MATCHING_PAGE_CREATE_BATCH_MAX_SIZE,
-  MatchingPageCreateMany
+  MatchingPageCreateMany,
+  ScanEnqueued,
+  ScanStatus,
+  ScanProgress,
+  ScanJobState
 } from "@vigilart/shared";
 import { ArtworksService } from "../artworks/artworks.service";
 import { StorageService } from "../storage/storage.service";
@@ -27,7 +34,9 @@ import { GoogleLensService } from "../googlelens/googlelens.service";
 import { assertResourceOwnership } from "../common/utils/ownership";
 import {
   MAX_SCANS_PER_WINDOW,
-  SCAN_WINDOW_DAYS
+  SCAN_WINDOW_DAYS,
+  REPORTS_QUEUE,
+  GENERATE_REPORT_JOB
 } from "./reports.constants";
 
 const REPORTS_STATS_TTL = 30 * 24 * 60 * 60 * 1000;
@@ -45,7 +54,8 @@ export class ReportsService {
     private readonly storageService: StorageService,
     private readonly matchingPagesService: MatchingPagesService,
     private readonly prisma: PrismaService,
-    @Inject(CACHE_MANAGER) private readonly cacheManager: Cache
+    @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
+    @InjectQueue(REPORTS_QUEUE) private readonly reportsQueue: Queue
   ) {}
 
   private readonly logger = new Logger(ReportsService.name);
@@ -97,11 +107,26 @@ export class ReportsService {
     return matchingPagesData;
   }
 
-  async findArtworksMatches(userId: string): Promise<string[]> {
+  // Progress reporting is best-effort: a transient Redis failure here must
+  // never reject and discard an otherwise-successful (already paid-for) scan.
+  private emitProgress(job: Job | undefined, processed: number, total: number) {
+    void job?.updateProgress({ processed, total }).catch(() => undefined);
+  }
+
+  async findArtworksMatches(userId: string, job?: Job): Promise<string[]> {
     const artworks = await this.artworksService.findAllPerUser(userId);
+    const total = artworks.length;
+    let processed = 0;
+    this.emitProgress(job, processed, total);
 
     const allMatches = await Promise.all(
-      artworks.map((artwork) => this.findArtworkMatches(artwork))
+      artworks.map((artwork) =>
+        this.findArtworkMatches(artwork).then((matches) => {
+          processed += 1;
+          this.emitProgress(job, processed, total);
+          return matches;
+        })
+      )
     );
     const matchingPagesData = allMatches.flat();
 
@@ -138,11 +163,11 @@ export class ReportsService {
       );
   }
 
-  async generate(userId: string): Promise<ArtworksReport> {
+  async generate(userId: string, job?: Job): Promise<ArtworksReport> {
     await this.checkScanQuota(userId);
     this.logger.log(`Generate new report for user ${userId}`);
 
-    const matchingPagesIds = await this.findArtworksMatches(userId);
+    const matchingPagesIds = await this.findArtworksMatches(userId, job);
     const report = await this.prisma.artworksReport.create({
       data: {
         userId,
@@ -158,6 +183,113 @@ export class ReportsService {
     });
     await this.cacheManager.del(REPORT_STATS_KEY(userId));
     return report;
+  }
+
+  private scanJobId(userId: string): string {
+    return `scan-${userId}`;
+  }
+
+  private isRunningState(state: string): boolean {
+    return (
+      state === "active" ||
+      state === "waiting" ||
+      state === "waiting-children" ||
+      state === "prioritized" ||
+      state === "delayed"
+    );
+  }
+
+  private mapJobState(state: string): ScanJobState {
+    switch (state) {
+      case "active":
+      case "completed":
+      case "failed":
+      case "delayed":
+        return state;
+      default:
+        return "waiting";
+    }
+  }
+
+  // Single-flight enqueue against the deterministic per-user job id. Any
+  // source (manual button, hourly scheduler) that targets the same user
+  // collapses onto the same job: a scan already in flight is reused, and a
+  // retained terminal job is cleared so a fresh scan can take its id. A
+  // crashed/stalled active job is left to BullMQ's own stalled-job recovery
+  // rather than being force-removed here.
+  private async enqueueScanJob(
+    userId: string,
+    options: JobsOptions
+  ): Promise<string> {
+    const jobId = this.scanJobId(userId);
+    const existing = await this.reportsQueue.getJob(jobId);
+    if (existing) {
+      const state = await existing.getState();
+      if (this.isRunningState(state)) {
+        return jobId;
+      }
+      // Terminal (completed/failed) job retained only so the status endpoint
+      // could read its result; clear it so the id can be reused.
+      await existing.remove().catch(() => undefined);
+    }
+
+    const job = await this.reportsQueue.add(
+      GENERATE_REPORT_JOB,
+      { userId },
+      { jobId, ...options }
+    );
+    return job.id ?? jobId;
+  }
+
+  // Enqueue an interactive async scan (fail fast, retain the finished job so
+  // the frontend can poll its result). Quota is checked up front for
+  // immediate feedback before a job is created.
+  async enqueueScan(userId: string): Promise<ScanEnqueued> {
+    await this.checkScanQuota(userId);
+    const jobId = await this.enqueueScanJob(userId, {
+      attempts: 1,
+      removeOnComplete: { age: 3600 },
+      removeOnFail: { age: 86400 }
+    });
+    return { jobId };
+  }
+
+  // Enqueue an auto-scan from the scheduler: retry-friendly and self-cleaning.
+  // Shares the deterministic id with manual scans so a user is never scanned
+  // twice concurrently. Quota is enforced later inside generate().
+  async enqueueScheduledScan(userId: string): Promise<void> {
+    await this.enqueueScanJob(userId, {
+      attempts: 3,
+      backoff: { type: "exponential", delay: 5000 },
+      removeOnComplete: true,
+      removeOnFail: 100
+    });
+  }
+
+  async getScanStatus(userId: string, jobId: string): Promise<ScanStatus> {
+    const job = await this.reportsQueue.getJob(jobId);
+    if (!job || job.data?.userId !== userId)
+      throw new NotFoundException("Scan job not found.");
+
+    const state = await job.getState();
+    // The job was evicted between getJob and getState; treat it as gone so the
+    // client fails fast instead of polling a phantom "waiting" job.
+    if (state === "unknown") throw new NotFoundException("Scan job not found.");
+    const progress =
+      job.progress && typeof job.progress === "object"
+        ? (job.progress as ScanProgress)
+        : null;
+
+    return {
+      jobId,
+      state: this.mapJobState(state),
+      progress,
+      reportId:
+        state === "completed" && typeof job.returnvalue === "string"
+          ? job.returnvalue
+          : null,
+      error: state === "failed" ? job.failedReason ?? "Scan failed." : null
+    };
   }
 
   async findMatchesByArtwork(

--- a/shared/src/schemas/Reports/index.ts
+++ b/shared/src/schemas/Reports/index.ts
@@ -38,4 +38,31 @@ export class ArtworksReportGetDTO extends createZodDto(
   ArtworksReportGetSchema
 ) {}
 
+export const ScanEnqueuedSchema = z.object({
+  jobId: z.string()
+});
+export class ScanEnqueuedDTO extends createZodDto(ScanEnqueuedSchema) {}
+
+export const ScanJobStateSchema = z.enum([
+  "waiting",
+  "active",
+  "completed",
+  "failed",
+  "delayed"
+]);
+
+export const ScanProgressSchema = z.object({
+  processed: z.number(),
+  total: z.number()
+});
+
+export const ScanStatusSchema = z.object({
+  jobId: z.string(),
+  state: ScanJobStateSchema,
+  progress: ScanProgressSchema.nullable(),
+  reportId: z.string().nullable(),
+  error: z.string().nullable()
+});
+export class ScanStatusDTO extends createZodDto(ScanStatusSchema) {}
+
 export * from "./VisualSearchResult";

--- a/shared/src/types/Reports/index.ts
+++ b/shared/src/types/Reports/index.ts
@@ -3,7 +3,11 @@ import { ArtworksReportSchema } from "../../schemas";
 import {
   ArtworksReportGetSchema,
   ArtworksReportGlobalStatisticsSchema,
-  ArtworksReportStatisticsSchema
+  ArtworksReportStatisticsSchema,
+  ScanStatusSchema,
+  ScanProgressSchema,
+  ScanJobStateSchema,
+  ScanEnqueuedSchema
 } from "../../schemas";
 
 export type ArtworksReport = z.infer<typeof ArtworksReportSchema>;
@@ -17,5 +21,13 @@ export type ArtworksReportStatistics = z.infer<
 export type ArtworksReportGlobalStatistics = z.infer<
   typeof ArtworksReportGlobalStatisticsSchema
 >;
+
+export type ScanStatus = z.infer<typeof ScanStatusSchema>;
+
+export type ScanProgress = z.infer<typeof ScanProgressSchema>;
+
+export type ScanJobState = z.infer<typeof ScanJobStateSchema>;
+
+export type ScanEnqueued = z.infer<typeof ScanEnqueuedSchema>;
 
 export * from "./VisualSearchResult";

--- a/web-app/public/locales/en/translation.json
+++ b/web-app/public/locales/en/translation.json
@@ -253,6 +253,9 @@
         "created_but_details_failed": "Report created, but failed to load details",
         "report_created": "Report created",
         "detections_found": "detections found",
+        "queued": "Queued…",
+        "scanning_artwork": "Scanning artwork {{processed}} of {{total}}",
+        "scan_failed": "The scan failed. Please try again.",
         "error": "Error"
     },
     "dmca_page": {

--- a/web-app/public/locales/fr/translation.json
+++ b/web-app/public/locales/fr/translation.json
@@ -253,6 +253,9 @@
         "created_but_details_failed": "Report créé, mais échec du chargement des détails",
         "report_created": "Report créé",
         "detections_found": "détections trouvées",
+        "queued": "En file d'attente…",
+        "scanning_artwork": "Analyse de l'artwork {{processed}} sur {{total}}",
+        "scan_failed": "L'analyse a échoué. Veuillez réessayer.",
         "error": "Erreur"
     },
     "dmca_page": {

--- a/web-app/src/app/dashboard/components/ActionButtons.tsx
+++ b/web-app/src/app/dashboard/components/ActionButtons.tsx
@@ -16,12 +16,21 @@ export default function ActionButtons({ onUploadComplete }: ActionButtonsProps) 
   const [uploadModalOpen, setUploadModalOpen] = useState(false);
   const [reportModalOpen, setReportModalOpen] = useState(false);
   const { t } = useTranslation();
-  const { loading, error, report, handleCreate, resetState } = useCreateReport();
+  const { loading, error, report, progress, handleCreate, resetState } =
+    useCreateReport();
 
   const handleReportButtonClick = async () => {
     resetState();
     setReportModalOpen(true);
     await handleCreate();
+  };
+
+  const handleReportModalOpenChange = (open: boolean) => {
+    setReportModalOpen(open);
+    // Closing the modal stops the UI polling (the scan keeps running server-side).
+    if (!open) {
+      resetState();
+    }
   };
 
   return (
@@ -52,10 +61,11 @@ export default function ActionButtons({ onUploadComplete }: ActionButtonsProps) 
       />
       <ReportModal
         open={reportModalOpen}
-        onOpenChange={setReportModalOpen}
+        onOpenChange={handleReportModalOpenChange}
         report={report}
         error={error}
         loading={loading}
+        progress={progress}
       />
     </>
   );

--- a/web-app/src/app/dashboard/components/ReportModal.tsx
+++ b/web-app/src/app/dashboard/components/ReportModal.tsx
@@ -10,7 +10,7 @@ import {
 } from "../../../components/ui/dialog";
 import { Button } from "../../../components/ui/button";
 import { AlertCircle, CheckCircle } from "lucide-react";
-import type { ReportData } from "@/src/hooks/useCreateReport";
+import type { ReportData, ScanProgress } from "@/src/hooks/useCreateReport";
 
 interface ReportModalProps {
   open: boolean;
@@ -18,6 +18,7 @@ interface ReportModalProps {
   report: ReportData | null;
   error: string | null;
   loading: boolean;
+  progress: ScanProgress | null;
 }
 
 export function ReportModal({
@@ -26,8 +27,16 @@ export function ReportModal({
   report,
   error,
   loading,
+  progress,
 }: ReportModalProps) {
   const { t, i18n } = useTranslation();
+  // Any progress object means the job is running; the bar only makes sense
+  // once there is at least one artwork to scan (avoids a 0/0 division).
+  const scanStarted = !!progress;
+  const hasBar = !!progress && progress.total > 0;
+  const percent = hasBar
+    ? Math.round((progress.processed / progress.total) * 100)
+    : 0;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -43,8 +52,26 @@ export function ReportModal({
         </DialogHeader>
 
         {loading ? (
-          <div className="flex items-center justify-center py-8">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+          <div className="py-8 space-y-4">
+            <div className="flex items-center justify-center">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+            </div>
+            <p className="text-center text-sm text-gray-600">
+              {scanStarted
+                ? t("artworks_report_page.scanning_artwork", {
+                    processed: progress.processed,
+                    total: progress.total,
+                  })
+                : t("artworks_report_page.queued")}
+            </p>
+            {hasBar && (
+              <div className="w-full bg-gray-200 rounded-full h-2">
+                <div
+                  className="bg-blue-600 h-2 rounded-full transition-all"
+                  style={{ width: `${percent}%` }}
+                />
+              </div>
+            )}
           </div>
         ) : error ? (
           <div className="flex gap-3 p-4 bg-red-50 rounded-lg border border-red-200">
@@ -139,10 +166,8 @@ export function ReportModal({
         ) : null}
 
         <div className="flex gap-3 justify-end pt-4 border-t">
-          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={loading}>
-            {error || report
-              ? t("dashboard_page.upload.cancel")
-              : t("artworks_report_page.processing")}
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {t("dashboard_page.upload.cancel")}
           </Button>
         </div>
       </DialogContent>

--- a/web-app/src/hooks/useCreateReport.ts
+++ b/web-app/src/hooks/useCreateReport.ts
@@ -1,10 +1,16 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useAuth } from "@/src/components/contexts/authContext";
 import { authenticatedFetch } from "@/src/utils/auth/authenticatedFetch";
 import { useTranslation } from "react-i18next";
-import type { MatchingPage as SharedMatchingPage } from "@vigilart/shared/types";
+import type {
+  MatchingPage as SharedMatchingPage,
+  ScanStatus,
+  ScanProgress,
+} from "@vigilart/shared/types";
+
+export type { ScanProgress };
 
 type MatchingPage = Omit<SharedMatchingPage, "firstDetectedAt"> & {
   firstDetectedAt: string;
@@ -21,16 +27,84 @@ interface UseCreateReportResult {
   loading: boolean;
   error: string | null;
   report: ReportData | null;
+  progress: ScanProgress | null;
   handleCreate: () => Promise<void>;
   resetState: () => void;
 }
+
+const POLL_INTERVAL_MS = 2000;
+// Give up (and surface an error) if a scan never reports terminal state.
+const POLL_TIMEOUT_MS = 10 * 60 * 1000;
+// Per-request ceiling so a hung connection can't stall a poll tick or the
+// final details fetch forever (native fetch has no timeout of its own).
+const REQUEST_TIMEOUT_MS = 15 * 1000;
 
 export function useCreateReport(): UseCreateReportResult {
   const { t } = useTranslation();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [report, setReport] = useState<ReportData | null>(null);
+  const [progress, setProgress] = useState<ScanProgress | null>(null);
   const { user, loading: userLoading } = useAuth();
+
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollingInFlight = useRef(false);
+  // Bumped on every new scan and on reset; an in-flight poll from a superseded
+  // run compares against this and bails before touching state.
+  const runIdRef = useRef(0);
+
+  const stopPolling = () => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+    pollingInFlight.current = false;
+  };
+
+  // Stop polling if the component using the hook unmounts (e.g. navigation).
+  // The backend job keeps running server-side; only the UI polling stops.
+  useEffect(() => stopPolling, []);
+
+  const failWith = (message: string) => {
+    stopPolling();
+    setError(message);
+    setLoading(false);
+  };
+
+  const fetchReportDetails = async (reportId: string, runId: number) => {
+    try {
+      const res = await authenticatedFetch(`/reports/details/${reportId}`, {
+        method: "GET",
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+      // The run was superseded (modal closed / new scan) while fetching.
+      if (runIdRef.current !== runId) {
+        return;
+      }
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ message: res.statusText }));
+        failWith(
+          `${t("artworks_report_page.created_but_details_failed")}: ${err.message || res.statusText}`
+        );
+        return;
+      }
+
+      const detailsResponse = await res.json();
+      if (runIdRef.current !== runId) {
+        return;
+      }
+      const reportData: ReportData = detailsResponse.data || detailsResponse;
+      setReport(reportData);
+      setLoading(false);
+    } catch {
+      // Timeout / network error — polling is already stopped, so surface an
+      // error rather than leaving the modal stuck on the spinner.
+      if (runIdRef.current === runId) {
+        failWith(t("artworks_report_page.scan_failed"));
+      }
+    }
+  };
 
   const handleCreate = async () => {
     if (userLoading) {
@@ -44,46 +118,100 @@ export function useCreateReport(): UseCreateReportResult {
 
     const userId = user.id;
 
+    stopPolling();
+    const runId = ++runIdRef.current;
     setError(null);
     setReport(null);
+    setProgress(null);
     setLoading(true);
 
     try {
-      const reportRes = await authenticatedFetch(`/reports/user/${userId}`, {
-        method: "POST"
-      });
+      const enqueueRes = await authenticatedFetch(
+        `/reports/user/${userId}/scan`,
+        { method: "POST" }
+      );
 
-      if (!reportRes.ok) {
-        const err = await reportRes.json().catch(() => ({ message: reportRes.statusText }));
-        setError(`${t("artworks_report_page.load_failed")}: ${err.message || reportRes.statusText}`);
-        setLoading(false);
+      if (!enqueueRes.ok) {
+        const err = await enqueueRes
+          .json()
+          .catch(() => ({ message: enqueueRes.statusText }));
+        failWith(
+          `${t("artworks_report_page.load_failed")}: ${err.message || enqueueRes.statusText}`
+        );
         return;
       }
 
-      const createdResponse = await reportRes.json();
-      const createdReport = createdResponse.data || createdResponse;
-      const reportId = createdReport?.id;
+      const enqueued = await enqueueRes.json();
+      const jobId = (enqueued.data || enqueued)?.jobId;
 
-      if (!reportId) {
-        setError(t("artworks_report_page.created_but_no_id"));
-        setLoading(false);
+      if (!jobId) {
+        failWith(t("artworks_report_page.created_but_no_id"));
         return;
       }
 
-      const reportDetailsRes = await authenticatedFetch(`/reports/details/${reportId}`, {
-        method: "GET"
-      });
+      const startedAt = Date.now();
+      // Clear any interval a concurrent/previous handleCreate may have set
+      // before overwriting the ref, so we never leak an orphaned poller.
+      stopPolling();
+      pollRef.current = setInterval(async () => {
+        // Enforce the overall deadline first — even if a poll is stuck
+        // in-flight — so a hung request can never disable the timeout.
+        if (runIdRef.current !== runId) {
+          return;
+        }
+        if (Date.now() - startedAt > POLL_TIMEOUT_MS) {
+          failWith(t("artworks_report_page.scan_failed"));
+          return;
+        }
+        // Skip if a previous poll is still in flight.
+        if (pollingInFlight.current) {
+          return;
+        }
+        pollingInFlight.current = true;
+        try {
+          const statusRes = await authenticatedFetch(
+            `/reports/user/${userId}/scan/${jobId}`,
+            { method: "GET", signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) }
+          );
+          // The user started/reset another run while we were awaiting.
+          if (runIdRef.current !== runId) {
+            return;
+          }
+          // Job is gone (evicted / never enqueued) — terminal, not transient.
+          if (statusRes.status === 404) {
+            failWith(t("artworks_report_page.scan_failed"));
+            return;
+          }
+          if (!statusRes.ok) {
+            return; // transient (5xx / network); bounded by POLL_TIMEOUT_MS
+          }
 
-      if (!reportDetailsRes.ok) {
-        const err = await reportDetailsRes.json().catch(() => ({ message: reportDetailsRes.statusText }));
-        setError(`${t("artworks_report_page.created_but_details_failed")}: ${err.message || reportDetailsRes.statusText}`);
-        setLoading(false);
-        return;
-      }
+          const body = await statusRes.json();
+          if (runIdRef.current !== runId) {
+            return;
+          }
+          const scan: ScanStatus = body.data || body;
 
-      const detailsResponse = await reportDetailsRes.json();
-      const reportData: ReportData = detailsResponse.data || detailsResponse;
-      setReport(reportData);
+          if (scan.progress) {
+            setProgress(scan.progress);
+          }
+
+          if (scan.state === "completed") {
+            stopPolling();
+            if (scan.reportId) {
+              await fetchReportDetails(scan.reportId, runId);
+            } else {
+              failWith(t("artworks_report_page.created_but_no_id"));
+            }
+          } else if (scan.state === "failed") {
+            failWith(scan.error || t("artworks_report_page.scan_failed"));
+          }
+        } catch {
+          // ignore transient poll errors; bounded by POLL_TIMEOUT_MS
+        } finally {
+          pollingInFlight.current = false;
+        }
+      }, POLL_INTERVAL_MS);
     } catch (e: unknown) {
       let errorMessage: string;
       if (e instanceof Error) {
@@ -97,22 +225,26 @@ export function useCreateReport(): UseCreateReportResult {
           errorMessage = String(e);
         }
       }
-      setError(`${t("artworks_report_page.error")}: ${errorMessage}`);
-    } finally {
-      setLoading(false);
+      failWith(`${t("artworks_report_page.error")}: ${errorMessage}`);
     }
   };
 
   const resetState = () => {
+    // Supersede any in-flight poll so it can't resurrect stale state.
+    runIdRef.current += 1;
+    stopPolling();
     setError(null);
     setReport(null);
+    setProgress(null);
+    setLoading(false);
   };
 
   return {
     loading,
     error,
     report,
+    progress,
     handleCreate,
-    resetState
+    resetState,
   };
 }


### PR DESCRIPTION
## Summary
Routes the manual **Create report** scan through the existing BullMQ queue instead of running it synchronously in the request. The `POST` now returns instantly (fixes the deployed-dev **502 Bad Gateway** from the long-held request) and the UI shows **live per-artwork progress** instead of a bare spinner. The old synchronous `POST /reports/user/:id` is left untouched for the mobile app.

## Backend
- **New endpoints:** `POST /reports/user/:id/scan` (enqueue → `{ jobId }`) and `GET /reports/user/:id/scan/:jobId` (state / progress / reportId / error).
- **Single-flight** enqueue on a deterministic `scan-${userId}` job id; the daily scheduler enqueues through the **same id**, so a user is never scanned twice concurrently (no duplicate reports / duplicate paid Vision+Lens calls).
- `generate()` emits best-effort per-artwork progress via `job.updateProgress`; the processor returns the `reportId` through `job.returnvalue`.
- Evicted jobs (`unknown` state) return **404** so the client fails fast instead of polling a phantom job.
- Added a request **timeout** to the Google Lens / BrightData call so a stalled provider can't hang a job.

## Frontend
- `useCreateReport` enqueues then polls every 2s. The overall **deadline is enforced even when a request hangs**, and every fetch has a **per-request abort timeout** (native `fetch` has none).
- **Run-token guards** stop a superseded run (modal closed / new scan) from resurrecting stale state; the poll interval is cleared before reassignment to avoid leaks.
- `ReportModal` shows queued / "Scanning artwork X of Y" with a determinate progress bar; closing the modal stops polling while the job finishes server-side.

## Review
Built from a high-effort `/code-review` of the feature: 8 of 10 findings fixed here (frontend hang/leak/stale-state, backend cross-source concurrency, evicted-job handling, zero-artwork display). Two deferred as follow-ups: **DB-level quota atomicity** (needs a migration) and a narrow **two-tab terminal-job race**.

## Verification
- backend build ✓ · web `tsc --noEmit` ✓
- `test:it` **45/45** · `test:e2e` **81/81**

## Follow-ups (not in this PR)
- Provision **Google Vision credentials** on deployed dev — the async endpoint fixes the 502, but the background job still needs Vision creds to succeed.
- Migrate **mobile** off the synchronous endpoint onto the async pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)