### PR TITLE
feat(reports): async scan with live progress + OOM-safe concurrency

### DIFF
--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -41,6 +41,12 @@ import {
 
 const REPORTS_STATS_TTL = 30 * 24 * 60 * 60 * 1000;
 
+// Cap how many artworks are scanned at once. Each artwork loads a full image
+// buffer into memory plus fires Vision + Google Lens calls, so an unbounded
+// Promise.all over every artwork can exhaust a small container's heap (OOM ->
+// SIGKILL -> the API dies mid-scan). A small pool bounds peak memory/IO.
+const SCAN_CONCURRENCY = 3;
+
 const REPORT_STATS_KEY = (userId: string) => {
   return `reports:statistics:${userId}`;
 }
@@ -113,20 +119,44 @@ export class ReportsService {
     void job?.updateProgress({ processed, total }).catch(() => undefined);
   }
 
+  // Concurrency-bounded map preserving input order. Runs at most `limit`
+  // invocations of `fn` at a time via a fixed pool of workers pulling from a
+  // shared cursor. Rejection semantics match Promise.all: the first rejection
+  // propagates (failing the scan), and every input promise still has a handler
+  // attached, so a later rejection never becomes an unhandledRejection.
+  private async mapWithConcurrency<T, R>(
+    items: T[],
+    limit: number,
+    fn: (item: T) => Promise<R>
+  ): Promise<R[]> {
+    const results: R[] = new Array<R>(items.length);
+    let cursor = 0;
+    const worker = async (): Promise<void> => {
+      while (cursor < items.length) {
+        const index = cursor++;
+        results[index] = await fn(items[index]);
+      }
+    };
+    const poolSize = Math.min(limit, items.length);
+    await Promise.all(Array.from({ length: poolSize }, () => worker()));
+    return results;
+  }
+
   async findArtworksMatches(userId: string, job?: Job): Promise<string[]> {
     const artworks = await this.artworksService.findAllPerUser(userId);
     const total = artworks.length;
     let processed = 0;
     this.emitProgress(job, processed, total);
 
-    const allMatches = await Promise.all(
-      artworks.map((artwork) =>
+    const allMatches = await this.mapWithConcurrency(
+      artworks,
+      SCAN_CONCURRENCY,
+      (artwork) =>
         this.findArtworkMatches(artwork).then((matches) => {
           processed += 1;
           this.emitProgress(job, processed, total);
           return matches;
         })
-      )
     );
     const matchingPagesData = allMatches.flat();
 


### PR DESCRIPTION
## Summary

Routes the manual web scan through the existing BullMQ queue instead of running the entire scan synchronously inside `POST /reports/user/:id`. The synchronous endpoint held the HTTP connection open for minutes, so the reverse proxy returned **502 Bad Gateway** on deployed dev (surfaced in the browser as a misleading "No Access-Control-Allow-Origin / CORS" error). The new async flow returns instantly and the web app shows **live scan progress** ("Scanning artwork X/Y") by polling a status endpoint.

The old synchronous `POST /reports/user/:id` is left untouched so the **mobile** app keeps working.

## Changes

**Backend**
- `POST /reports/user/:id/scan` — enqueues an async scan (single-flight per user via a deterministic `scan-<userId>` job id), checks the scan quota up front (fast 403), returns `{ jobId }`.
- `GET /reports/user/:id/scan/:jobId` — returns `{ jobId, state, progress, reportId?, error? }` built from the BullMQ job state; cross-checks `job.data.userId` against the path (404 on mismatch).
- `ReportsProcessor` now returns the created `reportId` so the poller can fetch details.
- `generate()` / `findArtworksMatches()` accept an optional `Job` and emit best-effort progress (`{ processed, total }`).
- **OOM-safe concurrency:** per-artwork scanning is bounded to `SCAN_CONCURRENCY = 3` via a new order-preserving `mapWithConcurrency` helper. The previous unbounded `Promise.all` loaded every artwork's image buffer + fired all Vision/Lens calls at once, exhausting the container heap (OOM → SIGKILL → 502 on the status poll).
- BrightData/Google Lens request gets a 30s timeout so a stalled call can't hang a job forever.

**Shared**
- New `ScanEnqueued` / `ScanStatus` / `ScanProgress` Zod schemas + types (source of truth).

**Web app**
- `useCreateReport` rewritten into enqueue + poll (2s interval, 10-min deadline, per-request 15s timeout, run-id guarding against superseded runs).
- `ReportModal` shows a determinate progress bar + "Scanning artwork X/Y" (indeterminate "Queued…" before `total` is known).
- i18n keys added (en/fr).

## Behavior notes
- **Cancel/close = stop polling, not cancel.** The background job keeps running and the report is still saved; the modal simply stops watching. (True server-side cancellation is a follow-up.)

## Testing
- `pnpm --filter backend build` ✅
- Backend integration tests: 45/45 ✅
- Backend e2e tests: 81/81 ✅

## Follow-ups (out of scope)
- Provision Google Vision credentials on dev, otherwise the background job completes as `failed` (cleanly — no longer a 502).
- Mobile app still uses the old synchronous endpoint.
- True server-side scan cancellation (`DELETE .../scan/:jobId` + in-flight abort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)