### PR TITLE
feat(reports): env-tunable scan concurrency + Lens timeout

### DIFF
--- a/backend/src/googlelens/googlelens.service.ts
+++ b/backend/src/googlelens/googlelens.service.ts
@@ -14,6 +14,7 @@ import {
 export class GoogleLensService {
   private readonly apiKey: string;
   private readonly zone: string;
+  private readonly timeoutMs: number;
 
   constructor(
     private readonly httpService: HttpService,
@@ -21,6 +22,10 @@ export class GoogleLensService {
   ) {
     this.apiKey = config.getOrThrow<string>("GOOGLE_LENS_API_KEY");
     this.zone = config.getOrThrow<string>("BRIGHTDATA_SERP_API_ZONE");
+    // Tunable via Doppler without a code change; BrightData Lens scrapes can
+    // legitimately take longer than the old 30s. Kept bounded so a truly hung
+    // call can't wedge a job forever.
+    this.timeoutMs = Number(config.get("GOOGLE_LENS_TIMEOUT_MS")) || 60000;
   }
 
   async getGoogleLensExactMatches(
@@ -39,7 +44,7 @@ export class GoogleLensService {
           url: `https://lens.google.com/uploadbyurl?url=${url}&brd_lens=exact_matches`,
           format: "raw"
         },
-        { headers, timeout: 30000 }
+        { headers, timeout: this.timeoutMs }
       )
     );
     if (!data || !data.exact_matches) {

--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -7,6 +7,7 @@ import {
   ServiceUnavailableException
 } from "@nestjs/common";
 import { CACHE_MANAGER } from "@nestjs/cache-manager";
+import { ConfigService } from "@nestjs/config";
 import type { Cache } from "cache-manager";
 import { InjectQueue } from "@nestjs/bullmq";
 import { Job, JobsOptions, Queue } from "bullmq";
@@ -45,7 +46,9 @@ const REPORTS_STATS_TTL = 30 * 24 * 60 * 60 * 1000;
 // buffer into memory plus fires Vision + Google Lens calls, so an unbounded
 // Promise.all over every artwork can exhaust a small container's heap (OOM ->
 // SIGKILL -> the API dies mid-scan). A small pool bounds peak memory/IO.
-const SCAN_CONCURRENCY = 3;
+// Tunable via the SCAN_CONCURRENCY env var (Doppler) so a memory-starved
+// deployment can drop it to 1 without a code change.
+const SCAN_CONCURRENCY_DEFAULT = 3;
 
 const REPORT_STATS_KEY = (userId: string) => {
   return `reports:statistics:${userId}`;
@@ -61,10 +64,15 @@ export class ReportsService {
     private readonly matchingPagesService: MatchingPagesService,
     private readonly prisma: PrismaService,
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
-    @InjectQueue(REPORTS_QUEUE) private readonly reportsQueue: Queue
-  ) {}
+    @InjectQueue(REPORTS_QUEUE) private readonly reportsQueue: Queue,
+    private readonly config: ConfigService
+  ) {
+    this.scanConcurrency =
+      Number(config.get("SCAN_CONCURRENCY")) || SCAN_CONCURRENCY_DEFAULT;
+  }
 
   private readonly logger = new Logger(ReportsService.name);
+  private readonly scanConcurrency: number;
 
   async aggregateVisualSearchResults(
     imageBuffer: Buffer,
@@ -150,7 +158,7 @@ export class ReportsService {
 
     const allMatches = await this.mapWithConcurrency(
       artworks,
-      SCAN_CONCURRENCY,
+      this.scanConcurrency,
       (artwork) =>
         this.findArtworkMatches(artwork).then((matches) => {
           processed += 1;


### PR DESCRIPTION
## Summary

Follow-up to #189. Makes the two scan knobs configurable via env (Doppler) so a memory-starved deployment can be tuned **without a code round-trip**:

- **`SCAN_CONCURRENCY`** (default `3`) — how many artworks are scanned in parallel.
- **`GOOGLE_LENS_TIMEOUT_MS`** (default `60000`) — BrightData/Google Lens request timeout (was a hardcoded 30s).

## Why

On deployed dev, the manual scan **crashes/restarts the backend container**, which surfaces as intermittent **502s on the status poll** (`GET /reports/user/:id/scan/:jobId`) — mislabeled in the browser as a CORS error. This was reproduced with pure `curl` (no browser): during a live scan the origin returns fast 502s (connection refused = process down), and the CORS preflight itself is a clean `204`, so it is **not** a CORS problem — the in-process scan worker is taking the API down with it.

A local memory-capped repro (`docker-compose.memtest.yml`, 256 MB, concurrency 3) did **not** crash, which points at the dev container having a smaller memory limit. Until the container memory is confirmed/raised, being able to set `SCAN_CONCURRENCY=1` in Doppler minimizes the scan's peak footprint and is the fastest mitigation.

## How to use on dev

1. Deploy this branch.
2. Set `SCAN_CONCURRENCY=1` in Doppler (dev) and restart so it's injected at startup.
3. Run a scan — the status poll should stop 502-ing.

If it still 502s at concurrency 1, the dev container is simply too small and needs a memory bump (infra/deployer action) — no code change scans images into a container that tight.

## Notes
- No schema change; `pnpm db:generate` not needed.
- `ConfigModule` is global, so `ReportsService` reads `SCAN_CONCURRENCY` and `GoogleLensService` reads `GOOGLE_LENS_TIMEOUT_MS` directly.
- Backend build ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)