### PR TITLE
fix(reports): drop Google Vision from scan + isolate per-artwork failures

### DIFF
--- a/backend/src/googlelens/googlelens.service.ts
+++ b/backend/src/googlelens/googlelens.service.ts
@@ -39,7 +39,9 @@ export class GoogleLensService {
           url: `https://lens.google.com/uploadbyurl?url=${url}&brd_lens=exact_matches`,
           format: "raw"
         },
-        { headers, timeout: 30000 }
+        // Google Lens is the only visual-search provider, so give BrightData
+        // generous headroom — its Lens scrapes can legitimately exceed 30s.
+        { headers, timeout: 60000 }
       )
     );
     if (!data || !data.exact_matches) {

--- a/backend/src/googlelens/googlelens.service.ts
+++ b/backend/src/googlelens/googlelens.service.ts
@@ -14,7 +14,6 @@ import {
 export class GoogleLensService {
   private readonly apiKey: string;
   private readonly zone: string;
-  private readonly timeoutMs: number;
 
   constructor(
     private readonly httpService: HttpService,
@@ -22,10 +21,6 @@ export class GoogleLensService {
   ) {
     this.apiKey = config.getOrThrow<string>("GOOGLE_LENS_API_KEY");
     this.zone = config.getOrThrow<string>("BRIGHTDATA_SERP_API_ZONE");
-    // Tunable via Doppler without a code change; BrightData Lens scrapes can
-    // legitimately take longer than the old 30s. Kept bounded so a truly hung
-    // call can't wedge a job forever.
-    this.timeoutMs = Number(config.get("GOOGLE_LENS_TIMEOUT_MS")) || 60000;
   }
 
   async getGoogleLensExactMatches(
@@ -44,7 +39,7 @@ export class GoogleLensService {
           url: `https://lens.google.com/uploadbyurl?url=${url}&brd_lens=exact_matches`,
           format: "raw"
         },
-        { headers, timeout: this.timeoutMs }
+        { headers, timeout: 30000 }
       )
     );
     if (!data || !data.exact_matches) {

--- a/backend/src/reports/reports.service.it-spec.ts
+++ b/backend/src/reports/reports.service.it-spec.ts
@@ -74,23 +74,16 @@ describe("ReportsService", () => {
   });
 
   describe("aggregateVisualSearchResults", () => {
-    it("Should merge matches from both providers", async () => {
-      visionService.searchImage.mockResolvedValue({
-        matchingPages: [{ url: "https://a.example" }]
-      });
+    it("Should return Google Lens matches", async () => {
       googleLensService.searchImage.mockResolvedValue({
         matchingPages: [{ url: "https://b.example" }]
       });
 
       const res = await service.aggregateVisualSearchResults(
-        Buffer.from(""),
         "https://download.example"
       );
 
-      expect(res).toEqual([
-        { url: "https://a.example" },
-        { url: "https://b.example" }
-      ]);
+      expect(res).toEqual([{ url: "https://b.example" }]);
     });
 
     it("Should return the surviving provider's matches when one provider fails", async () => {
@@ -100,7 +93,7 @@ describe("ReportsService", () => {
       });
 
       const res = await service.aggregateVisualSearchResults(
-        Buffer.from(""),
+        // Buffer.from(""),
         "https://download.example"
       );
 
@@ -112,7 +105,7 @@ describe("ReportsService", () => {
       googleLensService.searchImage.mockResolvedValue({ matchingPages: [] });
 
       const res = await service.aggregateVisualSearchResults(
-        Buffer.from(""),
+        // Buffer.from(""),
         "https://download.example"
       );
 
@@ -125,7 +118,7 @@ describe("ReportsService", () => {
 
       await expect(
         service.aggregateVisualSearchResults(
-          Buffer.from(""),
+          // Buffer.from(""),
           "https://download.example"
         )
       ).rejects.toBeInstanceOf(ServiceUnavailableException);

--- a/backend/src/reports/reports.service.it-spec.ts
+++ b/backend/src/reports/reports.service.it-spec.ts
@@ -194,6 +194,19 @@ describe("ReportsService", () => {
       expect(report).toEqual({ id: "report-1" });
     });
 
+    it("Should still complete the scan when one artwork's search fails", async () => {
+      mockScanSuccess();
+      // Two artworks; the first one's Lens call fails, the second succeeds.
+      googleLensService.searchImage
+        .mockReset()
+        .mockRejectedValueOnce(new Error("lens timeout"))
+        .mockResolvedValueOnce({ matchingPages: [] });
+
+      const report = await service.generate("user-id");
+
+      expect(report).toEqual({ id: "report-1" });
+    });
+
     it("Should not create a report when over quota", async () => {
       prisma.artworksReport.count.mockResolvedValue(MAX_SCANS_PER_WINDOW);
 

--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -61,14 +61,14 @@ export class ReportsService {
   private readonly logger = new Logger(ReportsService.name);
 
   async aggregateVisualSearchResults(
-    imageBuffer: Buffer,
+    // imageBuffer: Buffer,
     imageDownloadUrl: string
   ): Promise<MatchingPageGet[]> {
     const settledResults = await Promise.allSettled([
-      this.visionService.searchImage(imageBuffer),
+      // this.visionService.searchImage(imageBuffer),
       this.googleLensService.searchImage(imageDownloadUrl)
     ]);
-    const providers = ["vision", "googleLens"] as const;
+    const providers = ["googleLens"] as const;
     const matchingPages: MatchingPageGet[] = [];
     settledResults.forEach((result, index) => {
       if (result.status === "rejected") {
@@ -91,12 +91,12 @@ export class ReportsService {
   }
 
   async findArtworkMatches(artwork: Artwork): Promise<MatchingPageCreateMany> {
-    const imageBuffer = await this.storageService.getImage(artwork.storageKey);
+    // const imageBuffer = await this.storageService.getImage(artwork.storageKey);
     const imageDownloadUrl = await this.storageService.getDownloadUrl(
       artwork.storageKey
     );
     const matchingPages = await this.aggregateVisualSearchResults(
-      imageBuffer,
+      // imageBuffer,
       imageDownloadUrl
     );
     const matchingPagesData = matchingPages.map((match) => ({

--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -41,12 +41,6 @@ import {
 
 const REPORTS_STATS_TTL = 30 * 24 * 60 * 60 * 1000;
 
-// Cap how many artworks are scanned at once. Each artwork loads a full image
-// buffer into memory plus fires Vision + Google Lens calls, so an unbounded
-// Promise.all over every artwork can exhaust a small container's heap (OOM ->
-// SIGKILL -> the API dies mid-scan). A small pool bounds peak memory/IO.
-const SCAN_CONCURRENCY = 3;
-
 const REPORT_STATS_KEY = (userId: string) => {
   return `reports:statistics:${userId}`;
 }
@@ -119,44 +113,20 @@ export class ReportsService {
     void job?.updateProgress({ processed, total }).catch(() => undefined);
   }
 
-  // Concurrency-bounded map preserving input order. Runs at most `limit`
-  // invocations of `fn` at a time via a fixed pool of workers pulling from a
-  // shared cursor. Rejection semantics match Promise.all: the first rejection
-  // propagates (failing the scan), and every input promise still has a handler
-  // attached, so a later rejection never becomes an unhandledRejection.
-  private async mapWithConcurrency<T, R>(
-    items: T[],
-    limit: number,
-    fn: (item: T) => Promise<R>
-  ): Promise<R[]> {
-    const results: R[] = new Array<R>(items.length);
-    let cursor = 0;
-    const worker = async (): Promise<void> => {
-      while (cursor < items.length) {
-        const index = cursor++;
-        results[index] = await fn(items[index]);
-      }
-    };
-    const poolSize = Math.min(limit, items.length);
-    await Promise.all(Array.from({ length: poolSize }, () => worker()));
-    return results;
-  }
-
   async findArtworksMatches(userId: string, job?: Job): Promise<string[]> {
     const artworks = await this.artworksService.findAllPerUser(userId);
     const total = artworks.length;
     let processed = 0;
     this.emitProgress(job, processed, total);
 
-    const allMatches = await this.mapWithConcurrency(
-      artworks,
-      SCAN_CONCURRENCY,
-      (artwork) =>
+    const allMatches = await Promise.all(
+      artworks.map((artwork) =>
         this.findArtworkMatches(artwork).then((matches) => {
           processed += 1;
           this.emitProgress(job, processed, total);
           return matches;
         })
+      )
     );
     const matchingPagesData = allMatches.flat();
 

--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -7,7 +7,6 @@ import {
   ServiceUnavailableException
 } from "@nestjs/common";
 import { CACHE_MANAGER } from "@nestjs/cache-manager";
-import { ConfigService } from "@nestjs/config";
 import type { Cache } from "cache-manager";
 import { InjectQueue } from "@nestjs/bullmq";
 import { Job, JobsOptions, Queue } from "bullmq";
@@ -46,9 +45,7 @@ const REPORTS_STATS_TTL = 30 * 24 * 60 * 60 * 1000;
 // buffer into memory plus fires Vision + Google Lens calls, so an unbounded
 // Promise.all over every artwork can exhaust a small container's heap (OOM ->
 // SIGKILL -> the API dies mid-scan). A small pool bounds peak memory/IO.
-// Tunable via the SCAN_CONCURRENCY env var (Doppler) so a memory-starved
-// deployment can drop it to 1 without a code change.
-const SCAN_CONCURRENCY_DEFAULT = 3;
+const SCAN_CONCURRENCY = 3;
 
 const REPORT_STATS_KEY = (userId: string) => {
   return `reports:statistics:${userId}`;
@@ -64,15 +61,10 @@ export class ReportsService {
     private readonly matchingPagesService: MatchingPagesService,
     private readonly prisma: PrismaService,
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
-    @InjectQueue(REPORTS_QUEUE) private readonly reportsQueue: Queue,
-    private readonly config: ConfigService
-  ) {
-    this.scanConcurrency =
-      Number(config.get("SCAN_CONCURRENCY")) || SCAN_CONCURRENCY_DEFAULT;
-  }
+    @InjectQueue(REPORTS_QUEUE) private readonly reportsQueue: Queue
+  ) {}
 
   private readonly logger = new Logger(ReportsService.name);
-  private readonly scanConcurrency: number;
 
   async aggregateVisualSearchResults(
     imageBuffer: Buffer,
@@ -158,7 +150,7 @@ export class ReportsService {
 
     const allMatches = await this.mapWithConcurrency(
       artworks,
-      this.scanConcurrency,
+      SCAN_CONCURRENCY,
       (artwork) =>
         this.findArtworkMatches(artwork).then((matches) => {
           processed += 1;

--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -61,11 +61,9 @@ export class ReportsService {
   private readonly logger = new Logger(ReportsService.name);
 
   async aggregateVisualSearchResults(
-    // imageBuffer: Buffer,
     imageDownloadUrl: string
   ): Promise<MatchingPageGet[]> {
     const settledResults = await Promise.allSettled([
-      // this.visionService.searchImage(imageBuffer),
       this.googleLensService.searchImage(imageDownloadUrl)
     ]);
     const providers = ["googleLens"] as const;
@@ -91,12 +89,10 @@ export class ReportsService {
   }
 
   async findArtworkMatches(artwork: Artwork): Promise<MatchingPageCreateMany> {
-    // const imageBuffer = await this.storageService.getImage(artwork.storageKey);
     const imageDownloadUrl = await this.storageService.getDownloadUrl(
       artwork.storageKey
     );
     const matchingPages = await this.aggregateVisualSearchResults(
-      // imageBuffer,
       imageDownloadUrl
     );
     const matchingPagesData = matchingPages.map((match) => ({
@@ -119,16 +115,26 @@ export class ReportsService {
     let processed = 0;
     this.emitProgress(job, processed, total);
 
-    const allMatches = await Promise.all(
+    // Isolate per-artwork failures: one artwork's provider error (e.g. a Lens
+    // timeout) must not discard the matches already found for the others.
+    const settled = await Promise.allSettled(
       artworks.map((artwork) =>
-        this.findArtworkMatches(artwork).then((matches) => {
+        this.findArtworkMatches(artwork).finally(() => {
           processed += 1;
           this.emitProgress(job, processed, total);
-          return matches;
         })
       )
     );
-    const matchingPagesData = allMatches.flat();
+    const matchingPagesData = settled.flatMap((result, index) => {
+      if (result.status === "rejected") {
+        this.logger.error(
+          `Scan failed for artwork ${artworks[index].id}`,
+          result.reason
+        );
+        return [];
+      }
+      return result.value;
+    });
 
     const foundMatchesIds: string[] = [];
     for (


### PR DESCRIPTION
## Problem
On deployed dev, running a manual scan crashes/restarts the in-process backend, so the scan-status poll returns **502** (surfaced in the browser as a misleading "No Access-Control-Allow-Origin / CORS" error). Investigation pointed at memory: each artwork's full-resolution image was loaded into the server heap purely to feed Google Vision, which then base64-encodes it — a large per-artwork spike that can OOM-kill the small dev container. A `SCAN_CONCURRENCY=1` test on dev did **not** help, ruling out fan-out as the lever.

## Changes
- **Revert the speculative mitigations** — the `SCAN_CONCURRENCY` / `GOOGLE_LENS_TIMEOUT_MS` env knobs and the concurrency cap. The `SCAN_CONCURRENCY=1` test disproved the concurrency hypothesis, so these are removed to keep the code clean.
- **Drop Google Vision from the scan** — the scan no longer calls `StorageService.getImage()`; it hands the presigned URL straight to Google Lens (which already fetches the image off-box via BrightData). No image bytes are loaded on the server, eliminating the memory hog.
- **Isolate per-artwork failures** — `findArtworksMatches` now uses `Promise.allSettled`, so one artwork's Lens failure is logged and skipped instead of failing the entire scan (Lens is now the sole provider).
- **Raise the Lens timeout** 30s → 60s, since the scan now relies entirely on Lens.

## Trade-off
Detection is **Google Lens-only** now. `VisionService`/`VisionModule` remain wired but unused (kept in case Vision is re-enabled later, e.g. Vision-via-URL).

## Testing
- `pnpm --filter backend build` ✅
- Reports unit tests: **23/23** ✅ (incl. a new "one artwork fails, the rest still complete" test)
- E2E: **81/81** ✅

## Note / fallback
The confirmed *symptom* is that the in-process scan crashes the API; the crash *cause* (OOM vs. other) was never confirmed from dev logs. If dropping the image-buffer load doesn't fully fix dev, the cause-agnostic fallback — running the scan worker in a separate process — is saved on branch `feature/isolate-scan-worker`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
