### PR TITLE
fix(reports): fail scan loudly on total failure + Lens timeout 120s

### DIFF
--- a/backend/src/googlelens/googlelens.service.ts
+++ b/backend/src/googlelens/googlelens.service.ts
@@ -40,8 +40,8 @@ export class GoogleLensService {
           format: "raw"
         },
         // Google Lens is the only visual-search provider, so give BrightData
-        // generous headroom — its Lens scrapes can legitimately exceed 30s.
-        { headers, timeout: 60000 }
+        // generous headroom — measured Lens scrapes run ~40s+ and vary.
+        { headers, timeout: 120000 }
       )
     );
     if (!data || !data.exact_matches) {

--- a/backend/src/reports/reports.service.it-spec.ts
+++ b/backend/src/reports/reports.service.it-spec.ts
@@ -207,6 +207,18 @@ describe("ReportsService", () => {
       expect(report).toEqual({ id: "report-1" });
     });
 
+    it("Should fail the scan (no report) when every artwork's search fails", async () => {
+      mockScanSuccess();
+      googleLensService.searchImage
+        .mockReset()
+        .mockRejectedValue(new Error("lens timeout"));
+
+      await expect(service.generate("user-id")).rejects.toBeInstanceOf(
+        ServiceUnavailableException
+      );
+      expect(prisma.artworksReport.create).not.toHaveBeenCalled();
+    });
+
     it("Should not create a report when over quota", async () => {
       prisma.artworksReport.count.mockResolvedValue(MAX_SCANS_PER_WINDOW);
 

--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -136,6 +136,17 @@ export class ReportsService {
       return result.value;
     });
 
+    // If EVERY artwork failed, the scan never actually ran — fail the job so
+    // the user sees an error, instead of saving a misleading "0 detections".
+    if (
+      artworks.length > 0 &&
+      settled.every((result) => result.status === "rejected")
+    ) {
+      throw new ServiceUnavailableException(
+        "Scan failed: the visual search provider did not respond in time. Please try again."
+      );
+    }
+
     const foundMatchesIds: string[] = [];
     for (
       let i = 0;


### PR DESCRIPTION
Follow-up to #191 (already merged — that fixed the deployed-dev 502). Two issues surfaced while testing the now-Lens-only scan on dev.

## 1. Don't report a failed scan as "0 detections"
The per-artwork `Promise.allSettled` isolation from #191 also swallowed the case where **every** artwork fails — so when all Google Lens calls timed out, the scan saved a report with zero matches, indistinguishable from a genuine "scanned everything, found nothing." Now, if every artwork fails, `generate()` throws `ServiceUnavailableException` so the job fails visibly and the user sees an error. A **partial** failure still completes with the matches that were found.

## 2. Raise the Lens timeout 60s → 120s
A direct BrightData test measured a Lens scrape at **42.5s** on a small public image; real artwork scrapes vary and run longer. 60s was too tight (spurious timeouts), so bump to 120s for headroom. (Root cause of the recent Lens timeouts is BrightData/Google scrape latency, not the app — zone is active and funded.)

## Testing
- `pnpm --filter backend build` ✅
- Reports unit tests: **24/24** ✅ (incl. new "every artwork fails → job fails, no report" test)
- E2E: **81/81** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
