### PR TITLE
refactor(mobile): use 'matches' over 'detections' in scan UI

### DIFF
--- a/mobile-app/lib/pages/dashboard/scan_report/scan_result_page.dart
+++ b/mobile-app/lib/pages/dashboard/scan_report/scan_result_page.dart
@@ -97,7 +97,7 @@ class _ScanResultsPageState extends State<ScanResultsPage> {
 
       if (mounted) {
         final List<dynamic> matchingPages = reportData['matchingPages'] ?? [];
-        final int detectionCount = matchingPages.length;
+        final int matchCount = matchingPages.length;
 
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
@@ -105,7 +105,7 @@ class _ScanResultsPageState extends State<ScanResultsPage> {
               children: [
                 const Icon(Icons.check_circle, color: Colors.white),
                 const SizedBox(width: 12),
-                Expanded(child: Text('Scan complete! Found $detectionCount new detections.')),
+                Expanded(child: Text('Scan complete! Found $matchCount new matches.')),
               ],
             ), 
             backgroundColor: const Color(0xFF22C55E),

--- a/mobile-app/lib/pages/dashboard/scan_report/widgets/artwork_details_sheet.dart
+++ b/mobile-app/lib/pages/dashboard/scan_report/widgets/artwork_details_sheet.dart
@@ -75,7 +75,7 @@ class ArtworkDetailsSheet extends StatelessWidget {
           const SizedBox(height: 16),
           
           Text(
-            '${matches.length} Detections Found',
+            '${matches.length} Matches Found',
             style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
           ),
           const SizedBox(height: 16),

--- a/mobile-app/lib/pages/dashboard/scan_report/widgets/scan_result_card.dart
+++ b/mobile-app/lib/pages/dashboard/scan_report/widgets/scan_result_card.dart
@@ -74,7 +74,7 @@ class ScanResultCard extends StatelessWidget {
                         const SizedBox(width: 8),
                         Expanded(
                           child: Text(
-                            result['mostRecentSource'] != 'N/A' ? result['mostRecentSource'] : 'No detections',
+                            result['mostRecentSource'] != 'N/A' ? result['mostRecentSource'] : 'No matches',
                             style: TextStyle(color: Colors.grey[600], fontSize: 12),
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,


### PR DESCRIPTION
# Description

Renames the user-facing scan-result copy in the Flutter app from **"detections"** to **"matches"**, aligning the mobile wording with the domain terminology used across the backend and web app. A *match* is any page where an artwork was found; *detection* was an inconsistent alias for the same thing.

Text-only changes (plus one local variable rename `detectionCount` → `matchCount`) — no behavioural or API changes.

Affected strings:
- `scan_result_page.dart` — "Scan complete! Found N new **detections**." → "**matches**."
- `artwork_details_sheet.dart` — "N **Detections** Found" → "N **Matches** Found"
- `scan_result_card.dart` — empty-state fallback "No **detections**" → "No **matches**"

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

## Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [x] I have added sufficient documentation in the code
- [ ] I have provided enough screenshots or videos to better understand the PR

## Additional comments

Split out from the combined terminology PR (#219, closed) so the mobile and web changes can be reviewed and merged independently. The web-side changes live in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
